### PR TITLE
Add pool/trader safety functions gas tests

### DIFF
--- a/contracts/mocks/TestFlowMarginProtocol2.sol
+++ b/contracts/mocks/TestFlowMarginProtocol2.sol
@@ -48,4 +48,12 @@ contract TestFlowMarginProtocol2 is FlowMarginProtocol2 {
 
         return _getBidPrice(_pool, pair, _min).value;
     }
+
+    function getIsPoolSafe(LiquidityPoolInterface _pool) public returns (bool) {
+        return _isPoolSafe(_pool);
+    }
+
+    function getIsTraderSafe(LiquidityPoolInterface _pool, address _trader) public returns (bool) {
+        return _isTraderSafe(_pool, _trader);
+    }
 }


### PR DESCRIPTION
Larger tests are on skip, because they take way too much time. Results are

**getIsPoolSafe**:
```
10 positions in pool: 700K
50 positions in pool: 3.2M
100 positions in pool: 6.5M
```
**getIsTraderSafe**:
```
5 positions of trader: 274K
25 positions of trader: 1M
50 positions of trader: 1.9M
```

Two considerations about the gas costs:

### Maximum gas block limit

The block gas limit will tell us what is maximally allowed to use in one transaction. This value can change and is currently at 10M see https://etherscan.io/chart/gaslimit. I would say it's reasonable to assume that it will not drop below 8M again. Thus, 8M should be our absolute max consideration.

### Costs per transaction

Even though we can use 8M in each transaction, doesn't mean we should. https://ethgasstation.info/calculatorTxV.php shows the costs for a transaction in USD. This is at the moment extremely cheap, but I guess this is because of the recent price drops. On https://etherscan.io/chart/gasprice you can see gas prices of usually 15 Gwei. This would result in 13 USD per transaction in the above case of 100 positions in the pool. I have even seen gas prices of 50 Gwei which would be 38 USD. These USD values can further increase with a price increase of ETH.
