### PR TITLE
MarginProtocol MVP: Internal functions tests part 2

### DIFF
--- a/contracts/mocks/margin/TestFlowMarginProtocol1.sol
+++ b/contracts/mocks/margin/TestFlowMarginProtocol1.sol
@@ -32,10 +32,6 @@ contract TestFlowMarginProtocol1 is FlowMarginProtocol2 {
         return _getEquityOfTrader(_pool, _trader);
     }
 
-    function getLeveragedDebitsOfTrader(LiquidityPoolInterface _pool, address _trader) public view returns (uint256) {
-        return _getLeveragedDebitsOfTrader(_pool, _trader);
-    }
-
     function getUnrealizedPlOfTrader(LiquidityPoolInterface _pool, address _trader) public returns (int256) {
         return _getUnrealizedPlOfTrader(_pool, _trader);
     }

--- a/contracts/mocks/margin/TestFlowMarginProtocol1.sol
+++ b/contracts/mocks/margin/TestFlowMarginProtocol1.sol
@@ -28,10 +28,6 @@ contract TestFlowMarginProtocol1 is FlowMarginProtocol2 {
         return _getMarginLevel(_pool, _trader).value;
     }
 
-    function getEquityOfTrader(LiquidityPoolInterface _pool, address _trader) public returns (int256) {
-        return _getEquityOfTrader(_pool, _trader);
-    }
-
     function getUnrealizedPlOfTrader(LiquidityPoolInterface _pool, address _trader) public returns (int256) {
         return _getUnrealizedPlOfTrader(_pool, _trader);
     }

--- a/contracts/mocks/margin/TestFlowMarginProtocol2.sol
+++ b/contracts/mocks/margin/TestFlowMarginProtocol2.sol
@@ -24,4 +24,12 @@ contract TestFlowMarginProtocol2 is FlowMarginProtocol2 {
     function getPrice(IERC20 _baseCurrencyId, IERC20 _quoteCurrencyId) public returns (uint256) {
         return _getPrice(_baseCurrencyId, _quoteCurrencyId).value;
     }
+
+    function getLeveragedDebitsOfTrader(LiquidityPoolInterface _pool, address _trader) public view returns (uint256) {
+        return _getLeveragedDebitsOfTrader(_pool, _trader);
+    }
+
+    function getSwapRatesOfTrader(LiquidityPoolInterface _pool, address _trader) public view returns (uint256) {
+        return _getSwapRatesOfTrader(_pool, _trader);
+    }
 }

--- a/contracts/mocks/margin/TestFlowMarginProtocol2.sol
+++ b/contracts/mocks/margin/TestFlowMarginProtocol2.sol
@@ -32,4 +32,12 @@ contract TestFlowMarginProtocol2 is FlowMarginProtocol2 {
     function getSwapRatesOfTrader(LiquidityPoolInterface _pool, address _trader) public view returns (uint256) {
         return _getSwapRatesOfTrader(_pool, _trader);
     }
+
+    function getUnrealizedPlOfTrader(LiquidityPoolInterface _pool, address _trader) public returns (int256) {
+        return _getUnrealizedPlOfTrader(_pool, _trader);
+    }
+
+    function getEquityOfTrader(LiquidityPoolInterface _pool, address _trader) public returns (int256) {
+        return _getEquityOfTrader(_pool, _trader);
+    }
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -28,6 +28,8 @@ export const bn = (val: number | string | bigint): any =>
   new BN(val.toString());
 export const convertFromBaseToken = (baseTokenAmount: number | string) =>
   new BN(baseTokenAmount).mul(new BN(10));
+export const convertToBaseToken = (baseTokenAmount: number | string) =>
+  new BN(baseTokenAmount).div(new BN(10));
 
 export const ZERO = new BN(0);
 


### PR DESCRIPTION
All internal functions used and tested for MVP:
  
- `_getAccumulatedSwapRateOfPosition`
- `_removePositionFromList`
- `_getPrice`
- `_getUsdValue`
- `_getUnrealizedPlAndMarketPriceOfPosition `/ `_getUnrealizedPlOfPosition `/ `_getUnrealizedPlOfTrader`
- `_getLeveragedDebitsOfTrader`
- `_getSwapRatesOfTrader`
- `_getBidPrice`
- `_getAskPrice`
- `_getEquityOfTrader `