### PR TITLE
MarginProtocol: pool liquidation

### DIFF
--- a/contracts/impls/LiquidityPool.sol
+++ b/contracts/impls/LiquidityPool.sol
@@ -24,4 +24,8 @@ abstract contract LiquidityPool is Initializable, UpgradeOwnable, LiquidityPoolI
     function approveToProtocol(uint256 _amount) external override onlyOwner {
         moneyMarket.iToken().safeApprove(protocol, _amount);
     }
+
+    function owner() public view virtual override(UpgradeOwnable,LiquidityPoolInterface) returns (address) {
+        return UpgradeOwnable.owner();
+    }
 }

--- a/contracts/impls/margin/MarginFlowProtocol.sol
+++ b/contracts/impls/margin/MarginFlowProtocol.sol
@@ -642,7 +642,7 @@ contract MarginFlowProtocol is FlowProtocolBase {
             uint256 transferITokenAmount = uint256(-poolBalance);
 
             // approve might fail if MAX UINT is already approved
-            try _pool.approveLiquidityToProtocol(transferITokenAmount) {} catch (bytes memory) {}
+            try _pool.increaseAllowanceForProtocol(transferITokenAmount) {} catch (bytes memory) {}
             moneyMarket.iToken().safeTransferFrom(address(_pool), address(this), transferITokenAmount);
             balances[_pool][address(_pool)] = 0;
         }

--- a/contracts/impls/margin/MarginFlowProtocol.sol
+++ b/contracts/impls/margin/MarginFlowProtocol.sol
@@ -266,6 +266,20 @@ contract MarginFlowProtocol is FlowProtocolBase {
     }
 
     /**
+     * @dev Withdraw amount from pool balance for pool.
+     * @param _iTokenAmount The iToken amount to withdraw.
+     */
+    function withdrawForPool(uint256 _iTokenAmount) external nonReentrant poolIsVerified(MarginLiquidityPoolInterface(msg.sender)) {
+        require(_iTokenAmount > 0, "0");
+        MarginLiquidityPoolInterface pool = MarginLiquidityPoolInterface(msg.sender);
+
+        require(int256(_iTokenAmount) <= balances[pool][msg.sender], "WP1");
+
+        balances[pool][msg.sender] = balances[pool][msg.sender].sub(int256(_iTokenAmount));
+        moneyMarket.iToken().safeTransfer(msg.sender, _iTokenAmount);
+    }
+
+    /**
      * @dev Open a new position with a min/max price. Trader must pay fees for first position.
      * Set price to 0 if you want to use the current market price.
      * @param _pool The MarginLiquidityPool.

--- a/contracts/impls/margin/MarginFlowProtocolSafety.sol
+++ b/contracts/impls/margin/MarginFlowProtocolSafety.sol
@@ -290,13 +290,8 @@ contract MarginFlowProtocolSafety is Initializable, UpgradeOwnable, UpgradeReent
     {
         require(!isPoolSafe(_pool), "PM2");
 
-        marginProtocol.liquidityPoolRegistry().marginCallPool(_pool);
-        marginProtocol.moneyMarket().baseToken().safeTransfer(
-            msg.sender,
-            marginProtocol
-                .liquidityPoolRegistry()
-                .LIQUIDITY_POOL_MARGIN_CALL_FEE()
-        );
+        uint256 depositedITokens = marginProtocol.liquidityPoolRegistry().marginCallPool(_pool);
+        marginProtocol.moneyMarket().redeemTo(msg.sender, depositedITokens);
 
         emit LiquidityPoolMarginCalled(address(_pool));
     }

--- a/contracts/impls/margin/MarginFlowProtocolSafety.sol
+++ b/contracts/impls/margin/MarginFlowProtocolSafety.sol
@@ -499,9 +499,12 @@ contract MarginFlowProtocolSafety is Initializable, UpgradeOwnable, UpgradeReent
 
     // equityOfPool = liquidity - (allUnrealizedPl + allAccumulatedSwapRate)
     function getEquityOfPool(MarginLiquidityPoolInterface _pool) public returns (int256) {
-        uint256 liquidity = marginProtocol.moneyMarket().convertAmountToBase(
-            marginProtocol.moneyMarket().iToken().balanceOf(address(_pool))
-        );
+        int256 iTokensPool = int256(marginProtocol.moneyMarket().iToken().balanceOf(address(_pool)));
+        int256 iTokensProtocol = marginProtocol.balances(_pool, address(_pool));
+        int256 totalItokens = iTokensPool.add(iTokensProtocol);
+        uint256 liquidity = totalItokens > 0 ? marginProtocol.moneyMarket().convertAmountToBase(
+            uint256(totalItokens)
+        ) : 0;
 
         // allUnrealizedPl + allAccumulatedSwapRate
         int256 unrealizedPlAndRate = 0;

--- a/contracts/impls/margin/MarginLiquidityPool.sol
+++ b/contracts/impls/margin/MarginLiquidityPool.sol
@@ -23,6 +23,14 @@ contract MarginLiquidityPool is Initializable, UpgradeOwnable, LiquidityPool, Ma
         _;
     }
 
+    modifier onlyProtocolSafety() {
+        require(
+            msg.sender == address(MarginFlowProtocol(protocol).safetyProtocol()),
+            "Ownable: caller is not the protocol safety"
+        );
+        _;
+    }
+
     function setSpreadForPair(address _baseToken, address _quoteToken, uint256 _value) external override onlyOwner {
         spreadsPerTokenPair[_baseToken][_quoteToken] = _value;
 
@@ -40,8 +48,12 @@ contract MarginLiquidityPool is Initializable, UpgradeOwnable, LiquidityPool, Ma
         return moneyMarket.mint(_baseTokenAmount);
     }
 
-    function approveLiquidityToProtocol(uint _iTokenAmount) external override onlyProtocol returns (uint256) {
+    function increaseAllowanceForProtocol(uint _iTokenAmount) external override onlyProtocol {
         moneyMarket.iToken().safeIncreaseAllowance(protocol, _iTokenAmount);        
+    }
+
+    function increaseAllowanceForProtocolSafety(uint _iTokenAmount) external override onlyProtocolSafety {
+        moneyMarket.iToken().safeIncreaseAllowance(address(MarginFlowProtocol(protocol).safetyProtocol()), _iTokenAmount);        
     }
 
     function withdrawLiquidityOwner(uint256 _iTokenAmount) external override onlyOwner returns (uint256) {

--- a/contracts/impls/margin/MarginLiquidityPool.sol
+++ b/contracts/impls/margin/MarginLiquidityPool.sol
@@ -47,7 +47,7 @@ contract MarginLiquidityPool is Initializable, UpgradeOwnable, LiquidityPool, Ma
     function withdrawLiquidityOwner(uint256 _iTokenAmount) external override onlyOwner returns (uint256) {
         int256 protocolBalance = MarginFlowProtocol(protocol).balances(this, address(this));
         if (protocolBalance > 0) {
-            MarginFlowProtocol(protocol).withdraw(this, uint256(protocolBalance));
+            MarginFlowProtocol(protocol).withdrawForPool(uint256(protocolBalance));
         }
 
         uint256 baseTokenAmount = moneyMarket.redeemTo(msg.sender, _iTokenAmount);

--- a/contracts/impls/margin/MarginLiquidityPool.sol
+++ b/contracts/impls/margin/MarginLiquidityPool.sol
@@ -29,6 +29,10 @@ contract MarginLiquidityPool is Initializable, UpgradeOwnable, LiquidityPool, Ma
         emit SpreadUpdated(_baseToken, _quoteToken, _value);
     }
 
+    function owner() public view override(UpgradeOwnable,LiquidityPool,LiquidityPoolInterface) returns (address) {
+        return UpgradeOwnable.owner();
+    }
+
     function depositLiquidity(uint256 _baseTokenAmount) external override returns (uint256) {
         moneyMarket.baseToken().safeTransferFrom(msg.sender, address(this), _baseTokenAmount);
         moneyMarket.baseToken().approve(address(moneyMarket), _baseTokenAmount);

--- a/contracts/impls/margin/MarginLiquidityPoolRegistry.sol
+++ b/contracts/impls/margin/MarginLiquidityPoolRegistry.sol
@@ -79,7 +79,7 @@ contract MarginLiquidityPoolRegistry is Initializable, UpgradeOwnable, UpgradeRe
      * @param _pool The MarginLiquidityPool.
      */
     function marginCallPool(MarginLiquidityPoolInterface _pool) public returns (uint256) {
-        require(msg.sender == protocolSafety, "Only protocol can call this function");
+        require(msg.sender == protocolSafety, "Only safety protocol can call this function");
         require(!isMarginCalled[_pool], "PM1");
 
         uint256 marginCallITokens = poolMarginCallITokens[_pool];

--- a/contracts/impls/synthetic/SyntheticFlowToken.sol
+++ b/contracts/impls/synthetic/SyntheticFlowToken.sol
@@ -101,12 +101,12 @@ contract SyntheticFlowToken is ProtocolOwnable, ERC20, ERC20DetailedUpgradable {
         minted = position.minted;
     }
 
-    function addPosition(address poolAddr, uint additonalCollaterals, uint additionaMinted, uint liquidityPoolShares) external onlyProtocol {
+    function addPosition(address poolAddr, uint additonalCollaterals, uint additionalMinted, uint liquidityPoolShares) external onlyProtocol {
         uint exchangeRate = interestShareExchangeRate();
 
         LiquidityPoolPosition storage position = liquidityPoolPositions[poolAddr];
         position.collaterals = position.collaterals.add(additonalCollaterals);
-        position.minted = position.minted.add(additionaMinted);
+        position.minted = position.minted.add(additionalMinted);
 
         totalPrincipalAmount = totalPrincipalAmount.add(additonalCollaterals);
         _mintInterestShares(exchangeRate, poolAddr, liquidityPoolShares);

--- a/contracts/impls/synthetic/SyntheticLiquidityPool.sol
+++ b/contracts/impls/synthetic/SyntheticLiquidityPool.sol
@@ -74,11 +74,11 @@ contract SyntheticLiquidityPool is Initializable, UpgradeOwnable, LiquidityPool,
         spreadsPerToken[_token] = 0;
     }
 
-    function addCollateral(SyntheticFlowProtocol _protocol, SyntheticFlowToken _token, uint256 _baseTokenAmount) external override onlyOwner {
-        _protocol.addCollateral(_token, address(this), _baseTokenAmount);
+    function addCollateral(SyntheticFlowToken _token, uint256 _baseTokenAmount) external override onlyOwner {
+        SyntheticFlowProtocol(protocol).addCollateral(_token, address(this), _baseTokenAmount);
     }
 
-    function withdrawCollateral(SyntheticFlowProtocol _protocol, SyntheticFlowToken _token) external override onlyOwner {
-        _protocol.withdrawCollateral(_token);
+    function withdrawCollateral(SyntheticFlowToken _token) external override onlyOwner {
+        SyntheticFlowProtocol(protocol).withdrawCollateral(_token);
     }
 }

--- a/contracts/impls/synthetic/SyntheticLiquidityPool.sol
+++ b/contracts/impls/synthetic/SyntheticLiquidityPool.sol
@@ -22,6 +22,10 @@ contract SyntheticLiquidityPool is Initializable, UpgradeOwnable, LiquidityPool,
         collateralRatio = 0; // use fToken default        
     }
 
+    function owner() public view override(UpgradeOwnable,LiquidityPool,LiquidityPoolInterface) returns (address) {
+        return UpgradeOwnable.owner();
+    }
+
     function getBidSpread(address _fToken) external view override returns (uint256) {
         if (allowedTokens[_fToken] && spreadsPerToken[_fToken] > 0) {
             return spreadsPerToken[_fToken];

--- a/contracts/interfaces/LiquidityPoolInterface.sol
+++ b/contracts/interfaces/LiquidityPoolInterface.sol
@@ -6,5 +6,5 @@ interface LiquidityPoolInterface {
     function protocol() external returns (address);
     function moneyMarket() external returns (MoneyMarketInterface);
     function approveToProtocol(uint256 amount) external;
-    // function owner() external view returns (address);
+    function owner() external view returns (address);
 }

--- a/contracts/interfaces/MarginLiquidityPoolInterface.sol
+++ b/contracts/interfaces/MarginLiquidityPoolInterface.sol
@@ -5,7 +5,8 @@ import "./LiquidityPoolInterface.sol";
 
 interface MarginLiquidityPoolInterface is LiquidityPoolInterface {
     function depositLiquidity(uint256 _realized) external returns (uint256);
-    function approveLiquidityToProtocol(uint256 _realized) external returns (uint256);
+    function increaseAllowanceForProtocol(uint256 _realized) external;
+    function increaseAllowanceForProtocolSafety(uint256 _realized) external;
     function withdrawLiquidityOwner(uint256 _realized) external returns (uint256);
     function getLiquidity() external returns (uint256);
 

--- a/contracts/interfaces/SyntheticLiquidityPoolInterface.sol
+++ b/contracts/interfaces/SyntheticLiquidityPoolInterface.sol
@@ -6,8 +6,8 @@ import "../impls/synthetic/SyntheticFlowToken.sol";
 import "./LiquidityPoolInterface.sol";
 
 interface SyntheticLiquidityPoolInterface is LiquidityPoolInterface {
-    function addCollateral(SyntheticFlowProtocol protocol, SyntheticFlowToken token, uint256 baseTokenAmount) external;
-    function withdrawCollateral(SyntheticFlowProtocol protocol, SyntheticFlowToken token) external;
+    function addCollateral(SyntheticFlowToken token, uint256 baseTokenAmount) external;
+    function withdrawCollateral(SyntheticFlowToken token) external;
 
     function getBidSpread(address fToken) external view returns (uint256);
     function getAskSpread(address fToken) external view returns (uint256);

--- a/contracts/libs/upgrades/UpgradeOwnable.sol
+++ b/contracts/libs/upgrades/UpgradeOwnable.sol
@@ -29,7 +29,7 @@ contract UpgradeOwnable is Initializable, UpgradeContext {
     /**
      * @dev Returns the address of the current owner.
      */
-    function owner() public view returns (address) {
+    function owner() public view virtual returns (address) {
         return _owner;
     }
 

--- a/contracts/mocks/margin/MockIsPoolSafeMarginProtocol.sol
+++ b/contracts/mocks/margin/MockIsPoolSafeMarginProtocol.sol
@@ -4,7 +4,7 @@ pragma experimental ABIEncoderV2;
 import "../../impls/margin/MarginFlowProtocolSafety.sol";
 
 contract MockPoolIsSafeMarginProtocol {
-    event Withdrew(MarginLiquidityPoolInterface pool, address indexed sender, uint256 amount);
+    event FakeWithdrew(address sender, uint256 amount);
 
     function safetyProtocol() public view returns (MarginFlowProtocolSafety) {
         return MarginFlowProtocolSafety(address(this));
@@ -14,8 +14,8 @@ contract MockPoolIsSafeMarginProtocol {
         return address(_pool) != address(0);
     }
 
-    function withdraw(MarginLiquidityPoolInterface _pool, uint256 _iTokenAmount) public {
-        emit Withdrew(_pool, msg.sender, _iTokenAmount);
+    function withdrawForPool(uint256 _iTokenAmount) public {
+        emit FakeWithdrew(msg.sender, _iTokenAmount);
     }
 
     function balances(MarginLiquidityPoolInterface _pool, address _trader) public pure returns (uint256) {
@@ -26,7 +26,7 @@ contract MockPoolIsSafeMarginProtocol {
 }
 
 contract MockPoolIsNotSafeMarginProtocol {
-    event Withdrew(MarginLiquidityPoolInterface pool, address indexed sender, uint256 amount);
+    event FakeWithdrew(address sender, uint256 amount);
 
     function safetyProtocol() public view returns (MarginFlowProtocolSafety) {
         return MarginFlowProtocolSafety(address(this));
@@ -36,8 +36,8 @@ contract MockPoolIsNotSafeMarginProtocol {
         return address(_pool) == address(0);
     }
 
-    function withdraw(MarginLiquidityPoolInterface _pool, uint256 _iTokenAmount) public {
-        emit Withdrew(_pool, msg.sender, _iTokenAmount);
+    function withdrawForPool(uint256 _iTokenAmount) public {
+        emit FakeWithdrew(msg.sender, _iTokenAmount);
     }
 
     function balances(MarginLiquidityPoolInterface _pool, address _trader) public pure returns (uint256) {

--- a/migrations/deploy_contracts.ts
+++ b/migrations/deploy_contracts.ts
@@ -260,8 +260,8 @@ module.exports = (artifacts: Truffle.Artifacts, web3: Web3) => {
     const initialTraderRiskMarginCallThreshold = web3.utils.toWei('0.03');
     const initialTraderRiskLiquidateThreshold = web3.utils.toWei('0.01');
     const initialLiquidityPoolENPMarginThreshold = web3.utils.toWei('0.3');
-    const initialLiquidityPoolELLMarginThreshold = web3.utils.toWei('0.1');
-    const initialLiquidityPoolENPLiquidateThreshold = web3.utils.toWei('0.3');
+    const initialLiquidityPoolELLMarginThreshold = web3.utils.toWei('0.3');
+    const initialLiquidityPoolENPLiquidateThreshold = web3.utils.toWei('0.1');
     const initialLiquidityPoolELLLiquidateThreshold = web3.utils.toWei('0.1');
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
@@ -278,6 +278,7 @@ module.exports = (artifacts: Truffle.Artifacts, web3: Web3) => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     await (marginProtocolSafety as any).initialize(
       marginProtocol.address,
+      kovanDeployerAddr, // TODO laminar treasury
       initialTraderRiskMarginCallThreshold,
       initialTraderRiskLiquidateThreshold,
       initialLiquidityPoolENPMarginThreshold,
@@ -288,7 +289,7 @@ module.exports = (artifacts: Truffle.Artifacts, web3: Web3) => {
 
     await marginLiquidityPoolRegistry.initialize(
       moneyMarket.address,
-      marginProtocol.address,
+      marginProtocolSafety.address,
     );
     await baseToken.approve(
       marginLiquidityPoolRegistry.address,

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -77,6 +77,7 @@ export const messages = {
   bidPriceTooLow: 'Bid price too low',
   poolNotSafeAfterWithdrawal: 'Pool not safe after withdrawal',
   onlyProtocol: 'Only protocol can call this function',
+  onlyProtocolSafety: 'Only safety protocol can call this function',
   traderAlreadyMarginCalled: 'TM1',
   traderCannotBeMarginCalled: 'TM2',
   traderNotMarginCalled: 'TS1',

--- a/test/margin/marginFlowProtocol.ts
+++ b/test/margin/marginFlowProtocol.ts
@@ -51,6 +51,7 @@ contract('MarginFlowProtocol', accounts => {
   const bob = accounts[3];
   const eur = accounts[4];
   const jpy = accounts[5];
+  const laminarTreasury = accounts[6];
 
   let oracle: SimplePriceOracleInstance;
   let protocol: TestMarginFlowProtocolInstance;
@@ -81,7 +82,7 @@ contract('MarginFlowProtocol', accounts => {
     await oracle.setOracleDeltaLastLimit(fromPercent(100));
     await oracle.setOracleDeltaSnapshotLimit(fromPercent(100));
 
-    initialSpread = fromPip(10);
+    initialSpread = bn(28152000000000);
     initialUsdPrice = fromPercent(100);
     initialEurPrice = fromPercent(120);
     initialJpyPrice = fromPercent(200);
@@ -134,6 +135,7 @@ contract('MarginFlowProtocol', accounts => {
 
     await (protocolSafety as any).initialize(
       protocol.address,
+      laminarTreasury,
       fromPercent(5),
       fromPercent(2),
       fromPercent(50),

--- a/test/margin/marginFlowProtocolSafety.ts
+++ b/test/margin/marginFlowProtocolSafety.ts
@@ -79,16 +79,16 @@ contract('MarginFlowProtocolSafety', accounts => {
     await oracle.setOracleDeltaLastLimit(fromPercent(100));
     await oracle.setOracleDeltaSnapshotLimit(fromPercent(100));
 
-    initialSpread = fromPip(10);
+    initialSpread = bn(28152000000000);
     initialUsdPrice = fromPercent(100);
     initialEurPrice = fromPercent(120);
 
-    initialTraderRiskMarginCallThreshold = fromPercent(5);
-    initialTraderRiskLiquidateThreshold = fromPercent(2);
-    initialLiquidityPoolENPMarginThreshold = fromPercent(50);
+    initialTraderRiskMarginCallThreshold = fromPercent(3);
+    initialTraderRiskLiquidateThreshold = fromPercent(1);
+    initialLiquidityPoolENPMarginThreshold = fromPercent(30);
     initialLiquidityPoolELLMarginThreshold = fromPercent(10);
-    initialLiquidityPoolENPLiquidateThreshold = fromPercent(20);
-    initialLiquidityPoolELLLiquidateThreshold = fromPercent(2);
+    initialLiquidityPoolENPLiquidateThreshold = fromPercent(30);
+    initialLiquidityPoolELLLiquidateThreshold = fromPercent(1);
 
     usd = await createTestToken(
       [liquidityProvider, dollar(50000)],
@@ -526,7 +526,7 @@ contract('MarginFlowProtocolSafety', accounts => {
           });
         } catch (error) {
           expect.fail(
-            `Margin call transaction should not have been reverted: ${error}`,
+            `Liquidation transaction should not have been reverted: ${error}`,
           );
         }
       });
@@ -601,7 +601,7 @@ contract('MarginFlowProtocolSafety', accounts => {
     describe('when pool is below margin call threshold', () => {
       beforeEach(async () => {
         await liquidityPool.withdrawLiquidityOwner(dollar(199400));
-        await oracle.feedPrice(eur, fromPercent(130), { from: owner });
+        await oracle.feedPrice(eur, fromPercent(170), { from: owner });
       });
 
       it('allows margin calling of pool', async () => {
@@ -744,6 +744,207 @@ contract('MarginFlowProtocolSafety', accounts => {
             from: bob,
           }),
           messages.poolCannotBeMarginCalled,
+        );
+      });
+    });
+  });
+
+  describe('when liquidating a pool', () => {
+    let leverage: BN;
+    let depositInUsd: BN;
+    let leveragedHeldInEuro: BN;
+    let price: BN;
+    let LIQUIDITY_POOL_LIQUIDATION_FEE: BN;
+
+    beforeEach(async () => {
+      leverage = bn(20);
+      depositInUsd = dollar(80);
+      leveragedHeldInEuro = euro(100);
+      price = bn(0); // accept all
+      LIQUIDITY_POOL_LIQUIDATION_FEE = await liquidityPoolRegistry.LIQUIDITY_POOL_LIQUIDATION_FEE();
+
+      await protocol.deposit(liquidityPool.address, depositInUsd, {
+        from: alice,
+      });
+
+      await protocol.openPosition(
+        liquidityPool.address,
+        usd.address,
+        eur,
+        leverage,
+        leveragedHeldInEuro,
+        price,
+        { from: alice },
+      );
+    });
+
+    describe('when pool is below liquidation threshold', () => {
+      beforeEach(async () => {
+        await liquidityPool.withdrawLiquidityOwner(dollar(199400));
+        await oracle.feedPrice(eur, fromPercent(230), { from: owner });
+        await protocolSafety.marginCallLiquidityPool(liquidityPool.address, {
+          from: bob,
+        });
+      });
+
+      it('allows liquidating of pool', async () => {
+        try {
+          await protocolSafety.liquidateLiquidityPool(liquidityPool.address, {
+            from: bob,
+          });
+        } catch (error) {
+          console.log({ error });
+          expect.fail(
+            `Pool liquidation transaction should not have been reverted: ${error}`,
+          );
+        }
+      });
+
+      it('sends fee back to caller', async () => {
+        const balanceBefore = await usd.balanceOf(bob);
+        await protocolSafety.liquidateLiquidityPool(liquidityPool.address, {
+          from: bob,
+        });
+        const balanceAfter = await usd.balanceOf(bob);
+
+        expect(balanceAfter).to.be.bignumber.equal(
+          balanceBefore.add(LIQUIDITY_POOL_LIQUIDATION_FEE),
+        );
+      });
+
+      it('does not allow liquidating twice', async () => {
+        await protocolSafety.liquidateLiquidityPool(liquidityPool.address, {
+          from: bob,
+        });
+
+        await expectRevert(
+          protocolSafety.liquidateLiquidityPool(liquidityPool.address, {
+            from: bob,
+          }),
+          messages.poolCannotBeLiquidated,
+        );
+      });
+
+      it('uses up all liquidity for the position', async () => {
+        const aliceBalanceBefore = await protocol.balances(
+          liquidityPool.address,
+          alice,
+        );
+        const poolLiquidity = await liquidityPool.getLiquidity.call();
+
+        await protocolSafety.liquidateLiquidityPool(liquidityPool.address, {
+          from: bob,
+        });
+
+        const aliceBalanceDiff = (
+          await protocol.balances(liquidityPool.address, alice)
+        ).sub(aliceBalanceBefore);
+
+        expect(aliceBalanceDiff).to.be.bignumber.equal(poolLiquidity);
+      });
+    });
+
+    describe('when pool is below liquidation threshold with multiple positions', () => {
+      beforeEach(async () => {
+        await protocol.deposit(liquidityPool.address, depositInUsd, {
+          from: bob,
+        });
+
+        await protocol.openPosition(
+          liquidityPool.address,
+          usd.address,
+          eur,
+          leverage.mul(bn(2)),
+          leveragedHeldInEuro,
+          price,
+          { from: alice },
+        );
+        await protocol.openPosition(
+          liquidityPool.address,
+          usd.address,
+          eur,
+          leverage,
+          leveragedHeldInEuro,
+          price,
+          { from: bob },
+        );
+        await liquidityPool.withdrawLiquidityOwner(dollar(198000));
+        await oracle.feedPrice(eur, fromPercent(180), { from: owner });
+        await protocolSafety.marginCallLiquidityPool(liquidityPool.address, {
+          from: bob,
+        });
+      });
+
+      it('force closes all positions', async () => {
+        const aliceBalanceBefore = await protocol.balances(
+          liquidityPool.address,
+          alice,
+        );
+        const bobBalanceBefore = await protocol.balances(
+          liquidityPool.address,
+          bob,
+        );
+        const poolLiquidityBefore = await liquidityPool.getLiquidity.call();
+
+        await protocolSafety.liquidateLiquidityPool(liquidityPool.address, {
+          from: bob,
+        });
+        const aliceBalanceDiff = (
+          await protocol.balances(liquidityPool.address, alice)
+        ).sub(aliceBalanceBefore);
+        const bobBalanceDiff = (
+          await protocol.balances(liquidityPool.address, bob)
+        ).sub(bobBalanceBefore);
+        const poolLiquidityDiff = (await liquidityPool.getLiquidity.call()).sub(
+          poolLiquidityBefore,
+        );
+        const treasuryBalance = await iUsd.balanceOf(laminarTreasury);
+
+        const positionsByPoolLength = await protocol.getPositionsByPoolLength(
+          liquidityPool.address,
+        );
+
+        expect(positionsByPoolLength).to.be.bignumber.equals(bn(0));
+        expect(aliceBalanceDiff).to.be.bignumber.above(bn(0));
+        expect(bobBalanceDiff).to.be.bignumber.above(bn(0));
+        expect(treasuryBalance).to.be.bignumber.above(bn(0));
+
+        expect(poolLiquidityDiff).to.be.bignumber.equal(
+          aliceBalanceDiff
+            .add(bobBalanceDiff)
+            .add(treasuryBalance)
+            .mul(bn(-1)),
+        );
+      });
+
+      describe('when pool liquidity is not sufficient for all positions', () => {
+        beforeEach(async () => {
+          await oracle.feedPrice(eur, fromPercent(260), { from: owner });
+        });
+
+        it('force closes only the first positions', async () => {
+          await protocolSafety.liquidateLiquidityPool(liquidityPool.address, {
+            from: bob,
+          });
+          const poolLiquidityAfter = await liquidityPool.getLiquidity.call();
+
+          const positionsByPoolLength = await protocol.getPositionsByPoolLength(
+            liquidityPool.address,
+          );
+
+          expect(positionsByPoolLength).to.be.bignumber.above(bn(0));
+          expect(poolLiquidityAfter).to.be.bignumber.equals(bn(0));
+        });
+      });
+    });
+
+    describe('when pool is above liquidation threshold', () => {
+      it('does not allow liquidating of pool', async () => {
+        await expectRevert(
+          protocolSafety.liquidateLiquidityPool(liquidityPool.address, {
+            from: bob,
+          }),
+          messages.poolCannotBeLiquidated,
         );
       });
     });

--- a/test/margin/marginFlowProtocolSafety.ts
+++ b/test/margin/marginFlowProtocolSafety.ts
@@ -45,6 +45,7 @@ contract('MarginFlowProtocolSafety', accounts => {
   const bob = accounts[3];
   const charlie = accounts[4];
   const eur = accounts[5];
+  const laminarTreasury = accounts[6];
 
   let oracle: SimplePriceOracleInstance;
   let protocol: TestMarginFlowProtocolInstance;
@@ -136,6 +137,7 @@ contract('MarginFlowProtocolSafety', accounts => {
 
     await (protocolSafety as any).initialize(
       protocol.address,
+      laminarTreasury,
       initialTraderRiskMarginCallThreshold,
       initialTraderRiskLiquidateThreshold,
       initialLiquidityPoolENPMarginThreshold,

--- a/test/margin/marginLiquidityPool.ts
+++ b/test/margin/marginLiquidityPool.ts
@@ -209,7 +209,7 @@ contract('MarginLiquidityPool', accounts => {
       await liquidityPool.approveToProtocol(0, {
         from: liquidityProvider,
       });
-      await liquidityPool.approveLiquidityToProtocol(5000, {
+      await liquidityPool.increaseAllowanceForProtocol(5000, {
         from: protocol,
       });
       expect(

--- a/test/margin/marginLiquidityPoolRegistry.ts
+++ b/test/margin/marginLiquidityPoolRegistry.ts
@@ -60,10 +60,10 @@ contract('MarginLiquidityPoolRegistry', accounts => {
         expect(await liquidityPoolRegistry.isMarginCalled(newPool)).to.be.true;
       });
 
-      it('reverts for non-protocol caller', async () => {
+      it('reverts for non-protocol safety caller', async () => {
         await expectRevert(
           liquidityPoolRegistry.marginCallPool(newPool, { from: alice }),
-          messages.onlyProtocol,
+          messages.onlyProtocolSafety,
         );
       });
 
@@ -84,11 +84,11 @@ contract('MarginLiquidityPoolRegistry', accounts => {
         expect(await liquidityPoolRegistry.isMarginCalled(newPool)).to.be.false;
       });
 
-      it('reverts for non-protocol caller', async () => {
+      it('reverts for non-protocol safety caller', async () => {
         await liquidityPoolRegistry.marginCallPool(newPool, { from: protocol });
         await expectRevert(
           liquidityPoolRegistry.makePoolSafe(newPool, { from: alice }),
-          messages.onlyProtocol,
+          messages.onlyProtocolSafety,
         );
       });
 
@@ -118,7 +118,8 @@ contract('MarginLiquidityPoolRegistry', accounts => {
       });
 
       it('sets pool as registered', async () => {
-        expect(await liquidityPoolRegistry.poolHasPaidFees(newPool)).to.be.true;
+        expect(await liquidityPoolRegistry.poolHasPaidDeposits(newPool)).to.be
+          .true;
       });
 
       it('transfers the feeSum', async () => {


### PR DESCRIPTION
Includes
- implementation
- unit-tests
- cucumber-tests

Relies on first ENP/ELL implementation. Next up is version with computation per trading pair.